### PR TITLE
Add refresh button id for dashboard script

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -75,9 +75,10 @@ export default function Home() {
           </div>
           <div className="nav-controls">
             <div id="lastUpdate" className="lastUpdate">آخر تحديث: {lastUpdate}</div>
-            <button 
-              onClick={fetchData} 
-              className="btn refresh-btn" 
+            <button
+              id="refreshBtn"
+              onClick={fetchData}
+              className="btn refresh-btn"
               disabled={loading}
             >
               <i className={`fas fa-sync-alt ${loading ? 'fa-spin' : ''}`}></i>


### PR DESCRIPTION
## Summary
- choose to keep the dashboard refresh handled via the existing public/js/app.js script
- add an id attribute to the refresh button so the script can bind its click handler

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd90dee768833190c2f535dd92fdec