### PR TITLE
Refine dashboard layout classes and styles

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -32,8 +32,8 @@ export default function Home() {
       if (window.updateDashboard) {
         window.updateDashboard();
       }
-      
-  setLastUpdate(new Date().toLocaleString('ar-SA'));
+
+      setLastUpdate(new Date().toLocaleString('ar-SA'));
     } catch (e) {
       setError(e.message);
       console.error('Failed to fetch data:', e);
@@ -57,23 +57,23 @@ export default function Home() {
       <Script src="https://cdn.jsdelivr.net/npm/dayjs@1/dayjs.min.js" strategy="beforeInteractive" />
       <Script src="/js/app.js" strategy="afterInteractive" />
 
-      <div className="container">
-        <div className="topbar">
+      <div className="container dashboard-container">
+        <div className="topbar dashboard-topbar">
           <img src="/images/HRC_logo.png" alt="HRC Logo" className="logo logo-right" />
-          <div className="header-titles">
+          <div className="header-titles dashboard-header-titles">
             <h1 className="main-title">تنفيذ الهوية على مباني الهيئة</h1>
-            <div className="subtitle">تَغَيَّرَتْ هُوِّيَتُنَا وَقِيَمُنَا ثَابِتَةٌ</div>
+            <div className="subtitle dashboard-subtitle">تَغَيَّرَتْ هُوِّيَتُنَا وَقِيَمُنَا ثَابِتَةٌ</div>
           </div>
           <img src="/images/Sawaedna_Logo.png" alt="Sawaedna Logo" className="logo logo-left" />
         </div>
 
-        <div className="nav-bar">
-          <div className="tabs">
-            <div className="tab active" data-tab="summary">الملخص</div>
-            <div className="tab" data-tab="details">التفاصيل</div>
+        <div className="nav-bar dashboard-navbar">
+          <div className="tabs dashboard-tabs">
+            <div className="tab dashboard-tab active" data-tab="summary">الملخص</div>
+            <div className="tab dashboard-tab" data-tab="details">التفاصيل</div>
           </div>
-          <div className="nav-controls">
-            <div id="lastUpdate" className="lastUpdate">آخر تحديث: {lastUpdate}</div>
+          <div className="nav-controls dashboard-nav-controls">
+            <div id="lastUpdate" className="lastUpdate dashboard-last-update">آخر تحديث: {lastUpdate}</div>
             <button
               id="refreshBtn"
               onClick={fetchData}
@@ -86,78 +86,78 @@ export default function Home() {
             <button id="themeBtn" className="btn">🌓</button>
           </div>
         </div>
+        {error && (
+          <div className="dashboard-error-message">{error}</div>
+        )}
       </div>
 
-      <div className="right-aligned-content">
-        <div id="viewSummary">
-          <div className="filters" style={{ marginTop: '0px' }}>
-            <div className="filter-group">
+      <div className="right-aligned-content dashboard-content">
+        <div id="viewSummary" className="dashboard-summary-view">
+          <div className="filters dashboard-filters">
+            <div className="filter-group dashboard-filter-group">
               <select id="siteFilter" className="select"><option value="">كل المواقع</option></select>
               <select id="phaseFilter" className="select"><option value="">كل المراحل</option></select>
               <select id="itemFilter" className="select"><option value="">كل البنود الرئيسية</option></select>
-              <button id="clearFilter" className="btn clear-btn" style={{ display: 'none', marginRight: '8px', padding: '6px 10px', background: 'var(--danger)', border: 'none', borderRadius: '6px', color: 'white', cursor: 'pointer' }}>🔄 إزالة الفلتر</button>
-              <div id="kpiArea" className="grid" style={{ marginBottom: '12px' }}></div>
+              <button id="clearFilter" className="btn clear-btn dashboard-clear-button">🔄 إزالة الفلتر</button>
+              <div id="kpiArea" className="grid dashboard-kpi-area"></div>
             </div>
-            
           </div>
 
-          
-
-          <div className="paneeel" style={{ marginBottom: '12px' }}>
-            <div className="panel card" style={{ position: 'relative' }}>
-              <div className="panel-header">
+          <div className="paneeel dashboard-panel-layout">
+            <div className="panel card dashboard-plan-actual-panel">
+              <div className="panel-header dashboard-panel-header">
                 <h3>مخطط/فعلي</h3>
-                <div className="chart-filter">
-                  <select id="chartSiteFilter" className="select" style={{ fontSize: '10px', padding: '4px 6px' }}><option value="">كل المواقع</option></select>
+                <div className="chart-filter dashboard-chart-filter">
+                  <select id="chartSiteFilter" className="select dashboard-chart-site-filter"><option value="">كل المواقع</option></select>
                 </div>
               </div>
-              <canvas id="chartPlanActual" style={{ height: '200px' }}></canvas>
+              <canvas id="chartPlanActual" className="dashboard-plan-actual-canvas"></canvas>
             </div>
-            <div className="panel mapo" style={{ position: 'relative' }}>
-              <div className="panel-header">
+            <div className="panel mapo dashboard-map-panel">
+              <div className="panel-header dashboard-panel-header">
                 <h3>المواقع</h3>
-                <div className="map-filter">
-                  <select id="mapSiteFilter" className="select" style={{ fontSize: '12px', padding: '4px 6px' }}><option value="">كل المواقع</option></select>
+                <div className="map-filter dashboard-map-filter">
+                  <select id="mapSiteFilter" className="select dashboard-map-site-filter"><option value="">كل المواقع</option></select>
                 </div>
               </div>
-              <div id="map" style={{ height: '320px', borderRadius: '8px' }}></div>
+              <div id="map" className="dashboard-map"></div>
             </div>
           </div>
 
-          <div className="card full">
-            <div className="chart-header">
+          <div className="card full dashboard-performance-card">
+            <div className="chart-header dashboard-performance-header">
               <h3 id="performanceTitle">أداء المواقع</h3>
-              <button id="performanceClearFilter" className="btn clear-btn" style={{ display: 'none' }}>🔄 إزالة الفلتر</button>
+              <button id="performanceClearFilter" className="btn clear-btn dashboard-clear-button">🔄 إزالة الفلتر</button>
             </div>
-            <div id="donutArea" className="donuts"></div>
-            <div id="gaugeArea" style={{ display: 'none', textAlign: 'center', padding: '20px' }}></div>
+            <div id="donutArea" className="donuts dashboard-donut-area"></div>
+            <div id="gaugeArea" className="dashboard-gauge-area"></div>
           </div>
 
         </div>
 
-        <div id="viewDetails" style={{ display: 'none' }}>
-          <div className="table-wrap card" style={{ marginTop: '12px' }}>
-            <div className="table-controls">
+        <div id="viewDetails" className="dashboard-details-view">
+          <div className="table-wrap card dashboard-table-card">
+            <div className="table-controls dashboard-table-controls">
               <strong>التفاصيل</strong>
-              <div className="table-filters">
-                <select id="tableSiteFilter" className="select" style={{ fontSize: '12px' }}><option value="">كل المواقع</option></select>
-                <select id="tablePhaseFilter" className="select" style={{ fontSize: '12px' }}><option value="">كل المراحل</option></select>
-                <select id="tableItemFilter" className="select" style={{ fontSize: '12px' }}><option value="">كل البنود</option></select>
-                <button id="tableDetailsClearFilter" className="btn clear-btn" style={{ display: 'none', marginRight: '8px', padding: '6px 10px', background: 'var(--danger)', border: 'none', borderRadius: '6px', color: 'white', cursor: 'pointer' }}>🔄 إزالة الفلتر</button>
-                <input id="searchInput" placeholder="ابحث..." style={{ padding: '8px', borderRadius: '8px', background: 'var(--card)', color: 'var(--text)', border: '1px solid var(--glass)' }} />
+              <div className="table-filters dashboard-table-filters">
+                <select id="tableSiteFilter" className="select dashboard-table-select"><option value="">كل المواقع</option></select>
+                <select id="tablePhaseFilter" className="select dashboard-table-select"><option value="">كل المراحل</option></select>
+                <select id="tableItemFilter" className="select dashboard-table-select"><option value="">كل البنود</option></select>
+                <button id="tableDetailsClearFilter" className="btn clear-btn dashboard-clear-button">🔄 إزالة الفلتر</button>
+                <input id="searchInput" className="dashboard-search-input" placeholder="ابحث..." />
               </div>
             </div>
-            <div style={{ overflow: 'auto' }}>
+            <div className="dashboard-table-scroll">
               <table id="dataTable">
                 <thead id="tableHead"></thead>
                 <tbody id="tableBody"></tbody>
               </table>
             </div>
-            <div id="tableFooter" className="table-footer"></div>
+            <div id="tableFooter" className="table-footer dashboard-table-footer"></div>
           </div>
         </div>
       </div>
-      <div id="loader" className="loader" style={{ display: 'none' }}><div className="spinner"></div></div>
+      <div id="loader" className="loader dashboard-loader"><div className="spinner dashboard-spinner"></div></div>
     </>
   );
 }

--- a/styles/dashboard.css
+++ b/styles/dashboard.css
@@ -24,7 +24,8 @@ body.light{
   --chart-background:rgba(0,0,0,0.05);
 }
 
-.container{
+.container,
+.dashboard-container{
   max-width:1700px;
   margin:0px auto;
   padding:0px;
@@ -32,7 +33,8 @@ body.light{
   gap:0px;
 }
 
-.right-aligned-content {
+.right-aligned-content,
+.dashboard-content {
   max-width: 1800px;
   max-height: 850px;
   margin: 6px 8px 6px auto;
@@ -43,7 +45,8 @@ body.light{
   grid-template-rows: repeat(12,50px);
 }
 
-.topbar {
+.topbar,
+.dashboard-topbar {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -55,7 +58,8 @@ body.light{
   margin-top: 0;
 }
 
-.header-titles {
+.header-titles,
+.dashboard-header-titles {
   flex: 1;
   text-align: center;
   max-width: 600px;
@@ -72,7 +76,8 @@ body.light{
   letter-spacing: 0.2px;
 }
 
-.subtitle {
+.subtitle,
+.dashboard-subtitle {
   color: var(--muted);
   font-size: 16px;
   font-weight: 600;
@@ -150,9 +155,10 @@ body.light{
   transition:color 0.3s ease;
 }
 
-#map {
-  height:500px;
-  border-radius:12px;
+#map,
+#map.dashboard-map {
+  height:320px;
+  border-radius:8px;
   box-shadow:0 2px 8px rgba(0,0,0,0.1);
   margin:20px 0;
   background:var(--card);
@@ -199,7 +205,8 @@ body.light{
 }
 
 /* New navigation bar styles */
-.nav-bar {
+.nav-bar,
+.dashboard-navbar {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -209,12 +216,14 @@ body.light{
   height: 50px;
 }
 
-.tabs {
+.tabs,
+.dashboard-tabs {
   display: flex;
   gap: 8px;
 }
 
-.tab {
+.tab,
+.dashboard-tab {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -227,22 +236,26 @@ body.light{
   font-size: 14px;
 }
 
-.tab.active {
+.tab.active,
+.dashboard-tab.active {
   background: var(--accent1);
   color: #fff;
 }
 
-.tab:hover:not(.active) {
+.tab:hover:not(.active),
+.dashboard-tab:hover:not(.active) {
   background: var(--glass);
 }
 
-.nav-controls {
+.nav-controls,
+.dashboard-nav-controls {
   display: flex;
   align-items: center;
   gap: 12px;
 }
 
-.lastUpdate {
+.lastUpdate,
+.dashboard-last-update {
   color: var(--muted);
   font-size: 14px;
   font-weight: 500;
@@ -319,13 +332,18 @@ body.light{
 }
 
 /* tabs */
-.tabs{display:flex;gap:8px;margin-top:12px}
-.tab{padding:8px 12px;border-radius:10px;background:var(--card);cursor:pointer;border:1px solid rgba(255,255,255,0.03);transition:all 0.2s}
-.tab:hover{background:var(--glass)}
-.tab.active{box-shadow:0 6px 18px rgba(0,0,0,0.4);outline:2px solid rgba(79,140,255,0.08);background:linear-gradient(135deg,var(--accent1),var(--accent2))}
+.tabs,
+.dashboard-tabs{display:flex;gap:8px;margin-top:12px}
+.tab,
+.dashboard-tab{padding:8px 12px;border-radius:10px;background:var(--card);cursor:pointer;border:1px solid rgba(255,255,255,0.03);transition:all 0.2s}
+.tab:hover,
+.dashboard-tab:hover{background:var(--glass)}
+.tab.active,
+.dashboard-tab.active{box-shadow:0 6px 18px rgba(0,0,0,0.4);outline:2px solid rgba(79,140,255,0.08);background:linear-gradient(135deg,var(--accent1),var(--accent2))}
 
 /* filters */
-.filters{
+.filters,
+.dashboard-filters{
   margin:0 0 0 0;
   display:grid;
   gap:2px;
@@ -338,6 +356,27 @@ body.light{
   grid-template-columns: repeat(18,100px);
   grid-row-start: 1;
 }
+
+/* Dashboard specific wrappers */
+.dashboard-summary-view{display:block;width:100%;}
+.dashboard-clear-button{display:none;margin-right:8px;padding:6px 10px;border-radius:6px;}
+.dashboard-kpi-area{margin-bottom:12px;}
+.dashboard-panel-layout{margin-bottom:12px;align-items:start;}
+.dashboard-plan-actual-panel{position:relative;}
+.dashboard-plan-actual-canvas{width:100%;height:200px;}
+.dashboard-chart-site-filter{font-size:10px;padding:4px 6px;}
+.dashboard-map-site-filter{font-size:12px;padding:4px 6px;}
+.dashboard-map{height:320px;border-radius:8px;background:var(--card);width:100%;overflow:hidden;}
+.dashboard-performance-card{margin-top:0;}
+.dashboard-performance-header{align-items:center;}
+.dashboard-donut-area{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:12px;margin-top:12px;}
+.dashboard-gauge-area{display:none;text-align:center;padding:20px;}
+.dashboard-details-view{display:none;width:100%;}
+.dashboard-table-card{margin-top:12px;}
+.dashboard-table-select{font-size:12px;}
+.dashboard-search-input{padding:8px;border-radius:8px;background:var(--card);color:var(--text);border:1px solid var(--glass);}
+.dashboard-table-scroll{overflow:auto;}
+.dashboard-error-message{margin-top:8px;padding:10px;border-radius:8px;background:rgba(239,68,68,0.1);color:var(--danger);text-align:center;font-weight:600;}
 /*مخطط*/
 .card {
   background:var(--card);
@@ -360,7 +399,8 @@ body.light{
 
 /*خريطة*/
 
-.mapo {
+.mapo,
+.dashboard-map-panel {
   background:var(--card);
   border-radius:12px;
   padding:24px;
@@ -371,7 +411,8 @@ body.light{
   grid-row-end: 3;
 }
 
-.mapo:hover {
+.mapo:hover,
+.dashboard-map-panel:hover {
   transform:translateY(-2px);
   box-shadow:0 4px 12px rgba(0,0,0,0.1);
 }
@@ -392,7 +433,8 @@ body.light{
 
 /* KPI styles moved to grid section */
 
-.filter-group{
+.filter-group,
+.dashboard-filter-group{
   display:grid;
   margin: 0 0 0 0;
   gap:8px;
@@ -404,7 +446,8 @@ body.light{
 
 }
 
-.filter-group::after {
+.filter-group::after,
+.dashboard-filter-group::after {
   content: "";
   position: absolute;
   right: -6px;
@@ -415,7 +458,8 @@ body.light{
   background: var(--glass);
 }
 
-.filter-group:last-child::after {
+.filter-group:last-child::after,
+.dashboard-filter-group:last-child::after {
   display: none;
 }
 
@@ -457,7 +501,8 @@ body.light .select:focus{
   grid-template-columns:repeat(12, 126px);
   gap:12px
 }
-.paneeel{
+.paneeel,
+.dashboard-panel-layout{
   display:grid;
   grid-template-columns:repeat(5,355px);
   grid-template-rows: repeat(2,250px);
@@ -523,26 +568,30 @@ body.light .select:focus{
 }
 
 /* Chart filter overlay */
-.chart-filter{
+.chart-filter,
+.dashboard-chart-filter{
   z-index:10;
-  display:relative;
+  display:flex;
   gap:6px;
   align-items:center;
 }
-.map-filter{
+.map-filter,
+.dashboard-map-filter{
   z-index:1000;
   display:flex;
   gap:6px;
   align-items:center;
 }
-.panel-header {
+.panel-header,
+.dashboard-panel-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
   margin-bottom: 16px;
   width: 100%;
 }
-.panel-header h3 {
+.panel-header h3,
+.dashboard-panel-header h3 {
   margin: 0;
 }
 /* donuts area */
@@ -674,7 +723,8 @@ body.light .select:focus{
   box-shadow: 0 2px 8px rgba(0,0,0,0.2);
 }
 
-.chart-header {
+.chart-header,
+.dashboard-performance-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -706,8 +756,10 @@ body.light .select:focus{
 
 /* table */
 .table-wrap{grid-column:span 12;border-radius:12px;overflow:auto}
-.table-controls{display:flex;justify-content:space-between;align-items:center;padding:8px;flex-wrap:wrap;gap:8px}
-.table-filters{display:flex;gap:6px;align-items:center;flex-wrap:wrap}
+.table-controls,
+.dashboard-table-controls{display:flex;justify-content:space-between;align-items:center;padding:8px;flex-wrap:wrap;gap:8px}
+.table-filters,
+.dashboard-table-filters{display:flex;gap:6px;align-items:center;flex-wrap:wrap}
 table{width:100%;border-collapse:collapse;font-size:14px}
 thead th{
   position:sticky;
@@ -724,20 +776,23 @@ td,th{padding:8px;border-bottom:1px solid rgba(255,255,255,0.04)}
 tbody tr:hover{background:var(--glass)}
 
 /* footer count */
-.table-footer{padding:8px;color:var(--muted);text-align:left;font-size:12px}
+.table-footer,
+.dashboard-table-footer{padding:8px;color:var(--muted);text-align:left;font-size:12px}
 
 /* loader */
-.loader{
+.loader,
+.dashboard-loader{
   position:fixed;
   inset:0;
-  display:flex;
+  display:none;
   align-items:center;
   justify-content:center;
   background:linear-gradient(180deg,rgba(0,0,0,0.35),rgba(0,0,0,0.6));
   backdrop-filter:blur(4px);
   z-index:9999
 }
-.spinner{
+.spinner,
+.dashboard-spinner{
   width:72px;
   height:72px;
   border-radius:50%;
@@ -769,10 +824,14 @@ tbody tr:hover{background:var(--glass)}
 }
 @media(max-width:640px){
   .kpi{grid-column:span 12}
-  .container{padding:12px;margin:10px auto}
-  .topbar{flex-direction:column;text-align:center}
-  .donuts{grid-template-columns:1fr}
-  .filters{flex-wrap:wrap;gap:6px}
+  .container,
+  .dashboard-container{padding:12px;margin:10px auto}
+  .topbar,
+  .dashboard-topbar{flex-direction:column;text-align:center}
+  .donuts,
+  .dashboard-donut-area{grid-template-columns:1fr}
+  .filters,
+  .dashboard-filters{flex-wrap:wrap;gap:6px}
 }
 
 /* arabic numbers and text enhancements */


### PR DESCRIPTION
## Summary
- assign dashboard-specific classes to each top-level div in the main page while keeping the data-refresh behaviour intact
- expand the shared stylesheet with matching selectors, extracted inline styles, and fixes for the chart/map filter layouts
- surface API fetch errors in the dashboard so issues with the Excel feed are visible to users

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd95a4f1a88331bcb183515c270e33