### PR TITLE
Refactor dashboard layout with CSS grid

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -57,22 +57,22 @@ export default function Home() {
       <Script src="https://cdn.jsdelivr.net/npm/dayjs@1/dayjs.min.js" strategy="beforeInteractive" />
       <Script src="/js/app.js" strategy="afterInteractive" />
 
-      <div className="container dashboard-container">
-        <div className="topbar dashboard-topbar">
-          <img src="/images/HRC_logo.png" alt="HRC Logo" className="logo logo-right" />
+      <div className="dashboard-shell">
+        <header className="dashboard-header">
+          <img src="/images/HRC_logo.png" alt="شعار الهيئة" className="logo logo-right" />
           <div className="header-titles dashboard-header-titles">
             <h1 className="main-title">تنفيذ الهوية على مباني الهيئة</h1>
             <div className="subtitle dashboard-subtitle">تَغَيَّرَتْ هُوِّيَتُنَا وَقِيَمُنَا ثَابِتَةٌ</div>
           </div>
-          <img src="/images/Sawaedna_Logo.png" alt="Sawaedna Logo" className="logo logo-left" />
-        </div>
+          <img src="/images/Sawaedna_Logo.png" alt="شعار سواعدنا" className="logo logo-left" />
+        </header>
 
-        <div className="nav-bar dashboard-navbar">
+        <section className="dashboard-controls-bar">
           <div className="tabs dashboard-tabs">
             <div className="tab dashboard-tab active" data-tab="summary">الملخص</div>
             <div className="tab dashboard-tab" data-tab="details">التفاصيل</div>
           </div>
-          <div className="nav-controls dashboard-nav-controls">
+          <div className="dashboard-nav-controls">
             <div id="lastUpdate" className="lastUpdate dashboard-last-update">آخر تحديث: {lastUpdate}</div>
             <button
               id="refreshBtn"
@@ -83,79 +83,82 @@ export default function Home() {
               <i className={`fas fa-sync-alt ${loading ? 'fa-spin' : ''}`}></i>
               {loading ? 'جاري التحديث...' : 'تحديث الآن'}
             </button>
-            <button id="themeBtn" className="btn">🌓</button>
+            <button id="themeBtn" className="btn" type="button">🌓</button>
           </div>
-        </div>
+        </section>
+
         {error && (
           <div className="dashboard-error-message">{error}</div>
         )}
-      </div>
 
-      <div className="right-aligned-content dashboard-content">
-        <div id="viewSummary" className="dashboard-summary-view">
-          <div className="filters dashboard-filters">
-            <div className="filter-group dashboard-filter-group">
-              <select id="siteFilter" className="select"><option value="">كل المواقع</option></select>
-              <select id="phaseFilter" className="select"><option value="">كل المراحل</option></select>
-              <select id="itemFilter" className="select"><option value="">كل البنود الرئيسية</option></select>
-              <button id="clearFilter" className="btn clear-btn dashboard-clear-button">🔄 إزالة الفلتر</button>
-              <div id="kpiArea" className="grid dashboard-kpi-area"></div>
-            </div>
-          </div>
-
-          <div className="paneeel dashboard-panel-layout">
-            <div className="panel card dashboard-plan-actual-panel">
-              <div className="panel-header dashboard-panel-header">
-                <h3>مخطط/فعلي</h3>
-                <div className="chart-filter dashboard-chart-filter">
-                  <select id="chartSiteFilter" className="select dashboard-chart-site-filter"><option value="">كل المواقع</option></select>
+        <main className="dashboard-main">
+          <section id="viewSummary" className="dashboard-summary-view" aria-label="عرض الملخص">
+            <div className="summary-grid">
+              <section className="filters dashboard-filters summary-grid__filters">
+                <div className="filter-group dashboard-filter-group">
+                  <select id="siteFilter" className="select"><option value="">كل المواقع</option></select>
+                  <select id="phaseFilter" className="select"><option value="">كل المراحل</option></select>
+                  <select id="itemFilter" className="select"><option value="">كل البنود الرئيسية</option></select>
+                  <button id="clearFilter" className="btn clear-btn dashboard-clear-button" type="button">🔄 إزالة الفلتر</button>
                 </div>
-              </div>
-              <canvas id="chartPlanActual" className="dashboard-plan-actual-canvas"></canvas>
-            </div>
-            <div className="panel mapo dashboard-map-panel">
-              <div className="panel-header dashboard-panel-header">
-                <h3>المواقع</h3>
-                <div className="map-filter dashboard-map-filter">
-                  <select id="mapSiteFilter" className="select dashboard-map-site-filter"><option value="">كل المواقع</option></select>
+                <div id="kpiArea" className="grid dashboard-kpi-area"></div>
+              </section>
+
+              <section className="panel card dashboard-plan-actual-panel summary-grid__plan">
+                <div className="panel-header dashboard-panel-header">
+                  <h3>مخطط/فعلي</h3>
+                  <div className="chart-filter dashboard-chart-filter">
+                    <select id="chartSiteFilter" className="select dashboard-chart-site-filter"><option value="">كل المواقع</option></select>
+                  </div>
                 </div>
+                <canvas id="chartPlanActual" className="dashboard-plan-actual-canvas"></canvas>
+              </section>
+
+              <section className="panel card dashboard-map-panel summary-grid__map">
+                <div className="panel-header dashboard-panel-header">
+                  <h3>المواقع</h3>
+                  <div className="map-filter dashboard-map-filter">
+                    <select id="mapSiteFilter" className="select dashboard-map-site-filter"><option value="">كل المواقع</option></select>
+                  </div>
+                </div>
+                <div id="map" className="dashboard-map"></div>
+              </section>
+
+              <section className="card dashboard-performance-card summary-grid__performance">
+                <div className="chart-header dashboard-performance-header">
+                  <h3 id="performanceTitle">أداء المواقع</h3>
+                  <button id="performanceClearFilter" className="btn clear-btn dashboard-clear-button" type="button">🔄 إزالة الفلتر</button>
+                </div>
+                <div id="donutArea" className="donuts dashboard-donut-area"></div>
+                <div id="gaugeArea" className="dashboard-gauge-area"></div>
+              </section>
+            </div>
+          </section>
+
+          <section id="viewDetails" className="dashboard-details-view" aria-label="عرض التفاصيل">
+            <div className="details-grid">
+              <div className="card table-wrap dashboard-table-card details-grid__table">
+                <div className="table-controls dashboard-table-controls">
+                  <strong>التفاصيل</strong>
+                  <div className="table-filters dashboard-table-filters">
+                    <select id="tableSiteFilter" className="select dashboard-table-select"><option value="">كل المواقع</option></select>
+                    <select id="tablePhaseFilter" className="select dashboard-table-select"><option value="">كل المراحل</option></select>
+                    <select id="tableItemFilter" className="select dashboard-table-select"><option value="">كل البنود</option></select>
+                    <button id="tableDetailsClearFilter" className="btn clear-btn dashboard-clear-button" type="button">🔄 إزالة الفلتر</button>
+                    <input id="searchInput" className="dashboard-search-input" placeholder="ابحث..." />
+                  </div>
+                </div>
+                <div className="dashboard-table-scroll">
+                  <table id="dataTable">
+                    <thead id="tableHead"></thead>
+                    <tbody id="tableBody"></tbody>
+                  </table>
+                </div>
+                <div id="tableFooter" className="table-footer dashboard-table-footer"></div>
               </div>
-              <div id="map" className="dashboard-map"></div>
             </div>
-          </div>
-
-          <div className="card full dashboard-performance-card">
-            <div className="chart-header dashboard-performance-header">
-              <h3 id="performanceTitle">أداء المواقع</h3>
-              <button id="performanceClearFilter" className="btn clear-btn dashboard-clear-button">🔄 إزالة الفلتر</button>
-            </div>
-            <div id="donutArea" className="donuts dashboard-donut-area"></div>
-            <div id="gaugeArea" className="dashboard-gauge-area"></div>
-          </div>
-
-        </div>
-
-        <div id="viewDetails" className="dashboard-details-view">
-          <div className="table-wrap card dashboard-table-card">
-            <div className="table-controls dashboard-table-controls">
-              <strong>التفاصيل</strong>
-              <div className="table-filters dashboard-table-filters">
-                <select id="tableSiteFilter" className="select dashboard-table-select"><option value="">كل المواقع</option></select>
-                <select id="tablePhaseFilter" className="select dashboard-table-select"><option value="">كل المراحل</option></select>
-                <select id="tableItemFilter" className="select dashboard-table-select"><option value="">كل البنود</option></select>
-                <button id="tableDetailsClearFilter" className="btn clear-btn dashboard-clear-button">🔄 إزالة الفلتر</button>
-                <input id="searchInput" className="dashboard-search-input" placeholder="ابحث..." />
-              </div>
-            </div>
-            <div className="dashboard-table-scroll">
-              <table id="dataTable">
-                <thead id="tableHead"></thead>
-                <tbody id="tableBody"></tbody>
-              </table>
-            </div>
-            <div id="tableFooter" className="table-footer dashboard-table-footer"></div>
-          </div>
-        </div>
+          </section>
+        </main>
       </div>
       <div id="loader" className="loader dashboard-loader"><div className="spinner dashboard-spinner"></div></div>
     </>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -901,9 +901,9 @@
         this.classList.add("active");
         const view = this.dataset.tab;
         document.getElementById("viewSummary").style.display =
-          view === "summary" ? "block" : "none";
+          view === "summary" ? "grid" : "none";
         document.getElementById("viewDetails").style.display =
-          view === "details" ? "block" : "none";
+          view === "details" ? "grid" : "none";
         if (view === "summary") {
           renderCharts();
           renderPerformanceCharts();

--- a/styles/dashboard.css
+++ b/styles/dashboard.css
@@ -1,696 +1,494 @@
-:root{
-  --bg:#040812;
-  --card:#081226;
-  --muted:#9fb3d6;
-  --text:#eaf2ff;
-  --accent1:#4f8cff;
-  --accent2:#8b5cf6;
-  --success:#22c55e;
-  --danger:#ef4444;
-  --glass: rgba(255,255,255,0.03);
-  --chart-planned:#4f8cff;
-  --chart-actual:#22c55e;
-  --chart-background:rgba(255,255,255,0.05);
-}
-body{margin:0;font-family:'Cairo',sans-serif;background:var(--bg);color:var(--text);transition:all .3s ease}
-body.light{
-  --bg:#f7f9fc;
-  --card:#fff;
-  --muted:#6b7280;
-  --text:#09102a;
-  --glass:rgba(0,0,0,0.04);
-  --chart-planned:#4f8cff;
-  --chart-actual:#16a34a;
-  --chart-background:rgba(0,0,0,0.05);
+:root {
+  --bg: #040812;
+  --card: #081226;
+  --muted: #9fb3d6;
+  --text: #eaf2ff;
+  --accent1: #4f8cff;
+  --accent2: #8b5cf6;
+  --success: #22c55e;
+  --danger: #ef4444;
+  --glass: rgba(255, 255, 255, 0.04);
+  --chart-planned: #4f8cff;
+  --chart-actual: #22c55e;
+  --chart-background: rgba(255, 255, 255, 0.08);
 }
 
-.container,
-.dashboard-container{
-  max-width:1700px;
-  margin:0px auto;
-  padding:0px;
-  display:grid;
-  gap:0px;
+body {
+  margin: 0;
+  font-family: 'Cairo', sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  direction: rtl;
+  min-height: 100vh;
+  line-height: 1.6;
+  transition: background 0.3s ease, color 0.3s ease;
 }
 
-.right-aligned-content,
-.dashboard-content {
-  max-width: 1800px;
-  max-height: 850px;
-  margin: 6px 8px 6px auto;
-  padding: 8px;
-  display: grid;
-  gap: 8px;
-  grid-template-columns: repeat(18,100px);
-  grid-template-rows: repeat(12,50px);
+body.light {
+  --bg: #f7f9fc;
+  --card: #ffffff;
+  --muted: #6b7280;
+  --text: #09102a;
+  --glass: rgba(15, 23, 42, 0.06);
+  --chart-planned: #2563eb;
+  --chart-actual: #16a34a;
+  --chart-background: rgba(15, 23, 42, 0.08);
 }
 
-.topbar,
-.dashboard-topbar {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 4px 20px;
-  margin-bottom: 8px;
-  margin: 0 0 0 0;
-  max-width: 95%;
-  gap: 300px;
-  margin-top: 0;
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
 }
 
-.header-titles,
-.dashboard-header-titles {
-  flex: 1;
-  text-align: center;
-  max-width: 600px;
+a {
+  color: inherit;
+}
+
+.dashboard-shell {
+  width: min(1680px, 100%);
   margin: 0 auto;
-  padding: 0 40px;
-  transform: translateX(62px);
+  padding: 32px 40px 48px;
+  display: grid;
+  grid-template-rows: auto auto 1fr;
+  gap: 24px;
+}
+
+@media (max-width: 1024px) {
+  .dashboard-shell {
+    padding: 24px;
+  }
+}
+
+@media (max-width: 640px) {
+  .dashboard-shell {
+    padding: 16px;
+    gap: 16px;
+  }
+}
+
+.dashboard-header {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 32px;
+  background: var(--card);
+  border-radius: 24px;
+  border: 1px solid var(--glass);
+  padding: 20px 32px;
+  box-shadow: 0 15px 45px rgba(4, 8, 18, 0.28);
+}
+
+@media (max-width: 920px) {
+  .dashboard-header {
+    grid-template-columns: 1fr;
+    text-align: center;
+    gap: 16px;
+  }
+
+  .logo-right,
+  .logo-left {
+    justify-self: center;
+  }
+}
+
+.logo {
+  height: 82px;
+  width: auto;
+  object-fit: contain;
+  transition: transform 0.25s ease;
+  filter: drop-shadow(0 10px 24px rgba(0, 0, 0, 0.25));
+}
+
+.logo:hover {
+  transform: translateY(-4px) scale(1.03);
+}
+
+.dashboard-header-titles {
+  display: grid;
+  gap: 6px;
+  justify-items: center;
 }
 
 .main-title {
   margin: 0;
-  font-size: 26px;
-  color: var(--text);
-  white-space: nowrap;
-  letter-spacing: 0.2px;
+  font-size: 28px;
+  letter-spacing: 0.4px;
 }
 
-.subtitle,
-.dashboard-subtitle {
-  color: var(--muted);
+.subtitle {
+  margin: 0;
   font-size: 16px;
   font-weight: 600;
-  margin-top: 4px;
-  white-space: nowrap;
-  letter-spacing: 0.2px;
-}
-
-.controls {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  min-width: 200px;
-}
-
-.logo {
-  height: 80px;
-  width: auto;
-  object-fit: contain;
-  filter: drop-shadow(0 2px 4px rgba(0,0,0,0.1));
-  transition: transform 0.3s ease;
-  flex-shrink: 0;
-}
-
-.logo-left {
-  margin-right: auto;
-}
-
-.logo-right {
-  margin-left: auto;
-  margin-right: -40px;
-}
-
-.logo:hover {
-  transform: scale(1.05);
-}
-
-#subtitle {
   color: var(--muted);
-  font-size: 18px;
-  font-weight: 600;
-  margin-top: 4px;
-  text-align: right;
 }
 
-.gauge-container {
-  max-width:400px;
-  margin:0 auto;
-  padding:20px;
-  background:var(--card);
-  border-radius:12px;
-  box-shadow:0 2px 8px rgba(0,0,0,0.1);
-}
-.gauge-info {
-  margin-top:20px;
-  display:flex;
-  justify-content:space-around;
-  text-align:center;
-  padding:16px;
-  background:var(--glass);
-  border-radius:8px;
-}
-.gauge-item {
-  display:flex;
-  flex-direction:column;
-  gap:8px;
-}
-.gauge-label {
-  color:var(--muted);
-  font-size:14px;
-}
-.gauge-value {
-  font-size:20px;
-  font-weight:bold;
-  transition:color 0.3s ease;
-}
-
-#map,
-#map.dashboard-map {
-  height:320px;
-  border-radius:8px;
-  box-shadow:0 2px 8px rgba(0,0,0,0.1);
-  margin:20px 0;
-  background:var(--card);
-}
-
-/* Improve map popup styles */
-.leaflet-popup-content-wrapper {
-  background:var(--card);
-  color:var(--text);
-  border-radius:8px;
-}
-
-.leaflet-popup-tip {
-  background:var(--card);
-}
-
-.leaflet-container a {
-  color:var(--accent1);
-}
-.title-container{
-  display:flex;
-  align-items:center;
-  background:var(--card);
-  padding:12px 20px;
-  border-radius:8px;
-  box-shadow:0 2px 8px rgba(0,0,0,0.05);
-  transition:all 0.3s ease;
-  margin-bottom:4px;
-}
-.title-container:hover {
-  box-shadow:0 4px 12px rgba(0,0,0,0.1);
-  transform:translateY(-1px);
-}
-.title-container h1 {
-  font-size:24px;
-  font-weight:700;
-  color:var(--text);
-}
-.badge{background:linear-gradient(90deg,var(--accent1),var(--accent2));padding:6px 10px;border-radius:999px;font-weight:700}
-.controls{
-  display:flex;
-  gap:12px;
-  align-items:center
-}
-
-/* New navigation bar styles */
-.nav-bar,
-.dashboard-navbar {
-  display: flex;
-  justify-content: space-between;
+.dashboard-controls-bar {
+  display: grid;
+  grid-template-columns: auto 1fr;
   align-items: center;
-  border-bottom: 2px solid var(--glass);
-  padding: 0 6px 3px 6px;
-  margin-top: -12px;
-  height: 50px;
+  gap: 24px;
+  padding: 12px 24px;
+  background: var(--card);
+  border-radius: 20px;
+  border: 1px solid var(--glass);
+  box-shadow: 0 12px 30px rgba(4, 8, 18, 0.18);
+}
+
+@media (max-width: 820px) {
+  .dashboard-controls-bar {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+
+  .dashboard-nav-controls {
+    justify-content: space-between;
+  }
 }
 
 .tabs,
 .dashboard-tabs {
-  display: flex;
-  gap: 8px;
+  display: inline-flex;
+  gap: 12px;
+  align-items: center;
 }
 
 .tab,
 .dashboard-tab {
-  display: flex;
-  justify-content: center;
+  display: inline-flex;
   align-items: center;
-  padding: 2px 4px;
-  border-radius: 6px 6px 0 0;
+  justify-content: center;
+  padding: 8px 18px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: rgba(79, 140, 255, 0.12);
+  color: var(--text);
   cursor: pointer;
-  transition: all .2s ease;
-  user-select: none;
-  height: 15px;
   font-size: 14px;
+  font-weight: 600;
+  transition: all 0.2s ease;
+}
+
+.tab:hover,
+.dashboard-tab:hover {
+  background: rgba(79, 140, 255, 0.22);
 }
 
 .tab.active,
 .dashboard-tab.active {
-  background: var(--accent1);
+  background: linear-gradient(120deg, var(--accent1), var(--accent2));
+  border-color: transparent;
   color: #fff;
+  box-shadow: 0 8px 20px rgba(79, 140, 255, 0.25);
 }
 
-.tab:hover:not(.active),
-.dashboard-tab:hover:not(.active) {
-  background: var(--glass);
-}
-
-.nav-controls,
 .dashboard-nav-controls {
   display: flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 12px;
+  flex-wrap: wrap;
 }
 
 .lastUpdate,
 .dashboard-last-update {
-  color: var(--muted);
   font-size: 14px;
-  font-weight: 500;
-  border-left: 1px solid var(--glass);
-  padding-left: 16px;
-  margin-left: 4px;
+  color: var(--muted);
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--glass);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.btn {
+  appearance: none;
+  border: 1px solid var(--glass);
+  border-radius: 999px;
+  background: var(--card);
+  color: var(--text);
+  padding: 8px 16px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.btn:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(79, 140, 255, 0.25);
+  background: linear-gradient(120deg, rgba(79, 140, 255, 0.18), rgba(139, 92, 246, 0.18));
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 .refresh-btn {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  font-size: 13px;
+  background: linear-gradient(120deg, var(--success), #2ddf80);
+  color: #fff;
+  border: none;
 }
 
-#themeBtn {
-  padding: 6px 10px;
-  font-size: 13px;
+.refresh-btn:hover:not(:disabled) {
+  box-shadow: 0 12px 30px rgba(34, 197, 94, 0.3);
 }
 
-/* Enhanced subtitle styling */
-#subtitle{
-  color:var(--muted);
-  font-size:18px !important;
-  font-weight:600;
-  margin-top:4px;
-  letter-spacing: 0.5px;
+.clear-btn {
+  background: linear-gradient(120deg, var(--danger), #f87171);
+  color: #fff;
+  border: none;
 }
 
-/* buttons */
-.btn{
-  background:var(--card);
-  color:var(--text);
-  border:1px solid var(--glass);
-  padding:8px 12px;
-  border-radius:8px;
-  cursor:pointer;
-  font-size:14px;
-  transition:all 0.2s;
-}
-.btn:hover{
-  background:var(--accent1);
-  color:white;
-}
-.clear-btn{
-  background:var(--danger) !important;
-  color:white !important;
-  border:none !important;
-  font-weight:600;
-  animation:fadeIn 0.3s ease;
-}
-.clear-btn:hover{
-  background:rgba(239,68,68,0.8) !important;
-  transform:scale(1.02);
-}
-.refresh-btn{
-  background:var(--success) !important;
-  color:white !important;
-  border:none !important;
-  font-weight:600;
-  display:flex;
-  align-items:center;
-  gap:6px;
-}
-.refresh-btn:hover{
-  background:rgba(34,197,94,0.8) !important;
-  transform:scale(1.02);
+.dashboard-clear-button {
+  justify-self: start;
 }
 
-@keyframes fadeIn{
-  from{opacity:0;transform:translateY(-5px)}
-  to{opacity:1;transform:translateY(0)}
-}
-
-/* tabs */
-.tabs,
-.dashboard-tabs{display:flex;gap:8px;margin-top:12px}
-.tab,
-.dashboard-tab{padding:8px 12px;border-radius:10px;background:var(--card);cursor:pointer;border:1px solid rgba(255,255,255,0.03);transition:all 0.2s}
-.tab:hover,
-.dashboard-tab:hover{background:var(--glass)}
-.tab.active,
-.dashboard-tab.active{box-shadow:0 6px 18px rgba(0,0,0,0.4);outline:2px solid rgba(79,140,255,0.08);background:linear-gradient(135deg,var(--accent1),var(--accent2))}
-
-/* filters */
-.filters,
-.dashboard-filters{
-  margin:0 0 0 0;
-  display:grid;
-  gap:2px;
-  align-items:center;
-  flex-wrap:wrap;
-  background: var(--glass);
-  padding: 6px;
-  border-radius: 10px;
-  width: 1800px;
-  grid-template-columns: repeat(18,100px);
-  grid-row-start: 1;
-}
-
-/* Dashboard specific wrappers */
-.dashboard-summary-view{display:block;width:100%;}
-.dashboard-clear-button{display:none;margin-right:8px;padding:6px 10px;border-radius:6px;}
-.dashboard-kpi-area{margin-bottom:12px;}
-.dashboard-panel-layout{margin-bottom:12px;align-items:start;}
-.dashboard-plan-actual-panel{position:relative;}
-.dashboard-plan-actual-canvas{width:100%;height:200px;}
-.dashboard-chart-site-filter{font-size:10px;padding:4px 6px;}
-.dashboard-map-site-filter{font-size:12px;padding:4px 6px;}
-.dashboard-map{height:320px;border-radius:8px;background:var(--card);width:100%;overflow:hidden;}
-.dashboard-performance-card{margin-top:0;}
-.dashboard-performance-header{align-items:center;}
-.dashboard-donut-area{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:12px;margin-top:12px;}
-.dashboard-gauge-area{display:none;text-align:center;padding:20px;}
-.dashboard-details-view{display:none;width:100%;}
-.dashboard-table-card{margin-top:12px;}
-.dashboard-table-select{font-size:12px;}
-.dashboard-search-input{padding:8px;border-radius:8px;background:var(--card);color:var(--text);border:1px solid var(--glass);}
-.dashboard-table-scroll{overflow:auto;}
-.dashboard-error-message{margin-top:8px;padding:10px;border-radius:8px;background:rgba(239,68,68,0.1);color:var(--danger);text-align:center;font-weight:600;}
-/*مخطط*/
-.card {
-  background:var(--card);
-  border-radius:12px;
-  border:1px solid var(--glass);
-  padding:24px;
-  box-shadow:0 2px 8px rgba(0,0,0,0.05);
-  backdrop-filter: blur(6px);
-  transition:all 0.3s ease;
-  height: 250px;
-  text-align: center;
-  justify-content: center;
-}
-
-.card:hover {
-  transform:translateY(-2px);
-  box-shadow:0 4px 12px rgba(0,0,0,0.1);
-  height: 240px;
-}
-
-/*خريطة*/
-
-.mapo,
-.dashboard-map-panel {
-  background:var(--card);
-  border-radius:12px;
-  padding:24px;
-  box-shadow:0 2px 8px rgba(0,0,0,0.05);
-  transition:all 0.3s ease;
-  grid-column-start: 5;
-  grid-row-start: 1;
-  grid-row-end: 3;
-}
-
-.mapo:hover,
-.dashboard-map-panel:hover {
-  transform:translateY(-2px);
-  box-shadow:0 4px 12px rgba(0,0,0,0.1);
+.dashboard-main {
+  display: grid;
+  gap: 24px;
 }
 
 
-
-.donut-area {
-  margin:32px 0;
-  display:grid;
-  grid-template-columns:repeat(auto-fit,minmax(240px,1fr));
-  gap:24px;
+.dashboard-summary-view,
+.dashboard-details-view {
+  width: 100%;
 }
 
-.donut-card {
-  text-align:center;
-  padding:24px;
+.dashboard-summary-view {
+  display: grid;
 }
 
-/* KPI styles moved to grid section */
-
-.filter-group,
-.dashboard-filter-group{
-  display:grid;
-  margin: 0 0 0 0;
-  gap:8px;
-  align-items:center;
-  flex-wrap:wrap;
-  position: relative;
-  grid-template-columns: repeat(4,135px) repeat(7, 1fr);
-  grid-row-start: 1;
-
-}
-
-.filter-group::after,
-.dashboard-filter-group::after {
-  content: "";
-  position: absolute;
-  right: -6px;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 1px;
-  height: 20px;
-  background: var(--glass);
-}
-
-.filter-group:last-child::after,
-.dashboard-filter-group:last-child::after {
+.dashboard-details-view {
   display: none;
 }
 
-.select{
-  position: relative;
-  background:var(--card);
-  color:var(--text);
-  padding:8px 12px;
-  border-radius:8px;
-  border:1px solid var(--glass);
-  transition:all 0.2s;
-  min-width:120px;
+.summary-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  grid-template-areas:
+    'filters filters filters filters filters filters map map map map map map'
+    'filters filters filters filters filters filters map map map map map map'
+    'plan plan plan plan plan plan map map map map map map'
+    'performance performance performance performance performance performance performance performance performance performance performance performance';
+}
+
+.summary-grid__filters {
+  grid-area: filters;
+}
+
+.summary-grid__plan {
+  grid-area: plan;
+}
+
+.summary-grid__map {
+  grid-area: map;
+}
+
+.summary-grid__performance {
+  grid-area: performance;
+}
+
+@media (max-width: 1280px) {
+  .summary-grid {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+    grid-template-areas:
+      'filters filters filters filters filters filters'
+      'map map map map map map'
+      'plan plan plan plan plan plan'
+      'performance performance performance performance performance performance';
+  }
+}
+
+@media (max-width: 720px) {
+  .summary-grid {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      'filters'
+      'map'
+      'plan'
+      'performance';
+    gap: 16px;
+  }
+}
+
+.filters,
+.dashboard-filters {
+  background: var(--card);
+  border-radius: 24px;
+  border: 1px solid var(--glass);
+  padding: 24px;
+  display: grid;
+  gap: 20px;
+  box-shadow: 0 15px 38px rgba(4, 8, 18, 0.22);
+}
+
+.filter-group,
+.dashboard-filter-group {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+  align-items: stretch;
+}
+
+.select {
+  background: var(--card);
+  color: var(--text);
+  border: 1px solid var(--glass);
+  border-radius: 14px;
+  padding: 10px 14px;
+  font-size: 14px;
+  font-family: inherit;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
   cursor: pointer;
 }
 
-.select:hover {
+.select:focus {
+  outline: none;
   border-color: var(--accent1);
+  box-shadow: 0 0 0 3px rgba(79, 140, 255, 0.25);
 }
 
-.select option {
+.dashboard-kpi-area {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
+}
+
+.grid {
+  display: grid;
+  gap: 16px;
+}
+
+.card {
+  background: var(--card);
+  border-radius: 24px;
+  border: 1px solid var(--glass);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  box-shadow: 0 18px 40px rgba(4, 8, 18, 0.22);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 22px 48px rgba(79, 140, 255, 0.18);
+}
+
+.panel-header,
+.dashboard-panel-header,
+.chart-header,
+.dashboard-performance-header,
+.table-controls,
+.dashboard-table-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.dashboard-plan-actual-panel {
+  min-height: 360px;
+  justify-content: space-between;
+}
+
+.dashboard-plan-actual-canvas {
+  width: 100% !important;
+  height: 100% !important;
+  min-height: 280px;
+}
+
+.dashboard-map-panel {
+  position: relative;
+  min-height: 480px;
+}
+
+.dashboard-map {
+  width: 100%;
+  height: 100%;
+  min-height: 420px;
+  border-radius: 20px;
+  overflow: hidden;
+  border: 1px solid var(--glass);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.leaflet-popup-content-wrapper,
+.leaflet-popup-tip {
   background: var(--card);
   color: var(--text);
-  padding: 8px;
-}
-.select:focus{outline:2px solid var(--accent1);background:var(--glass)}
-body.light .select{
-  background:white;
-  border:1px solid #e5e7eb;
-  color:var(--text);
-}
-body.light .select:focus{
-  border-color:var(--accent1);
-  box-shadow:0 0 0 2px rgba(79,140,255,0.1);
 }
 
-/* grid */
-.grid{
-  display:grid;
-  grid-template-columns:repeat(12, 126px);
-  gap:12px
-}
-.paneeel,
-.dashboard-panel-layout{
-  display:grid;
-  grid-template-columns:repeat(5,355px);
-  grid-template-rows: repeat(2,250px);
-  gap:12px
+.dashboard-performance-card {
+  padding-bottom: 32px;
 }
 
-.kpi{
-  grid-template-columns:auto;
-  padding: 10px;
-  min-width: 70px;
-  max-height: 30px;
+.dashboard-donut-area {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.dashboard-gauge-area {
+  display: none;
+  margin-top: 16px;
+}
+
+.gauge-container {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 18px;
+  padding: 24px;
+}
+
+.gauge-info {
+  margin-top: 16px;
   display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
+  gap: 16px;
+  justify-content: space-around;
 }
 
-.kpi h3{
-  margin: 0;
+.gauge-item {
+  text-align: center;
+  display: grid;
+  gap: 6px;
+}
+
+.gauge-label {
   color: var(--muted);
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.3px;
-  text-align: center;
-  justify-content: center;
-  white-space: nowrap;
-}
-
-.kpi .value{
-  font-size: 16px;
-  font-weight: 700;
-  margin-top: 6px;
-  background: linear-gradient(45deg,var(--accent1),var(--accent2));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-  text-align: center;
-  justify-content: center;
-}
-.kpi-sites { 
-  grid-column-start: 3;
-
- }
-.kpi-plan { background: rgba(0, 255, 128, 0.1); }
-.kpi-actual { background: rgba(255, 128, 0, 0.1); }
-.kpi-delta { background: rgba(255, 0, 0, 0.1); }
-.kpi-duration { background: rgba(0, 0, 255, 0.05); }
-.kpi-elapsed { background: rgba(0, 255, 0, 0.05); }
-.kpi-remaining { background: rgba(255, 255, 0, 0.05); }
-
-
-/* panels */
-.panel{
-    padding:12px;
-  position:relative;
-  
-}
-
-.full{
-  
-  padding:12px;
-  
-}
-
-/* Chart filter overlay */
-.chart-filter,
-.dashboard-chart-filter{
-  z-index:10;
-  display:flex;
-  gap:6px;
-  align-items:center;
-}
-.map-filter,
-.dashboard-map-filter{
-  z-index:1000;
-  display:flex;
-  gap:6px;
-  align-items:center;
-}
-.panel-header,
-.dashboard-panel-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 16px;
-  width: 100%;
-}
-.panel-header h3,
-.dashboard-panel-header h3 {
-  margin: 0;
-}
-/* donuts area */
-.donuts{
-  display:grid;
-  grid-template-columns:repeat(auto-fit,minmax(200px,1fr));
-  gap:12px;
-  margin-top:12px
-}
-.donut-card{
-  padding:12px;
-  text-align:center;
-  transition:all 0.2s;
-  cursor:pointer;
-  position:relative;
-}
-.donut-card:hover{
-  transform:scale(1.02);
-  background:var(--glass);
-}
-.donut-info {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  font-size: 11px;
-  font-weight: 600;
-  text-align: center;
-  color: var(--text);
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-  min-width: 80px;
-  max-width: 120px;
-  width: 60%;
-  text-shadow: 1px 1px 1px rgba(0,0,0,0.2);
-}
-.donut-info > div {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.donut-card canvas {
-  position: relative;
-  z-index: 1;
-}
-.donut-values .planned {
-  color: var(--accent2);
-}
-.donut-filters{
-  position:absolute;
-  top:8px;
-  right:8px;
-  display:flex;
-  flex-direction:column;
-  gap:4px;
-}
-.donut-filters .select{
-  font-size:11px;
-  padding:4px 6px;
-  min-width:80px;
-}
-
-/* gauge area */
-#gaugeArea{
-  background:var(--glass);
-  border-radius:10px;
-  margin-top:12px;
-}
-.gauge-info{
-  display:flex;
-  justify-content:space-around;
-  font-size:14px;
-  margin-top:10px;
-}
-
-/* Date displays */
-.date-display {
-  display: flex;
-  align-items: center;
-  gap: 8px;
   font-size: 13px;
+}
+
+.gauge-value {
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.kpi {
+  text-align: center;
+  gap: 12px;
+}
+
+.kpi h3 {
+  margin: 0;
+  font-size: 16px;
   color: var(--muted);
 }
 
-.date-display .gregorian {
-  color: var(--text);
-  font-weight: 600;
-}
-
-.date-display .hijri {
-  color: var(--accent1);
-  font-weight: 600;
-}
-
-/* Number formats */
-.percentage {
+.value {
+  font-size: 24px;
   font-weight: 700;
-  font-feature-settings: "tnum";
+  font-feature-settings: 'tnum';
+}
+
+.percentage {
+  font-feature-settings: 'tnum';
   font-variant-numeric: tabular-nums;
 }
 
@@ -702,162 +500,137 @@ body.light .select:focus{
   color: var(--danger);
 }
 
-/* Chart labels */
-.chart-label {
-  position: relative;
-  padding: 4px 8px;
-  background: var(--card);
-  border: 1px solid var(--glass);
-  border-radius: 4px;
-  font-size: 10px;
-  font-weight: 600;
-  pointer-events: none;
-  white-space: nowrap;
-  z-index: 10;
-  transition: opacity 0.2s;
+.details-grid {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: 24px;
 }
 
-.chart-label.hover {
-  background: var(--accent1);
-  color: white;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+.details-grid__table {
+  grid-column: 1 / -1;
 }
 
-.chart-header,
-.dashboard-performance-header {
+.dashboard-table-card {
+  padding: 24px;
+}
+
+.dashboard-table-filters {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  margin-bottom: 16px;
+  gap: 10px;
+  flex-wrap: wrap;
 }
 
-/* Table Styles */
-.table-container {
-  margin-top: 20px;
+.dashboard-search-input {
   background: var(--card);
-  border-radius: 8px;
-  padding: 16px;
-  overflow-x: auto;
-}
-.gauge-item{
-  text-align:center;
-  flex:1;
-}
-.gauge-label{
-  display:block;
-  font-size:12px;
-  color:var(--muted);
-  margin-bottom:4px;
-}
-.gauge-value{
-  font-weight:700;
-  font-size:16px;
+  color: var(--text);
+  border: 1px solid var(--glass);
+  border-radius: 14px;
+  padding: 10px 14px;
+  font-size: 14px;
+  min-width: 200px;
 }
 
-/* table */
-.table-wrap{grid-column:span 12;border-radius:12px;overflow:auto}
-.table-controls,
-.dashboard-table-controls{display:flex;justify-content:space-between;align-items:center;padding:8px;flex-wrap:wrap;gap:8px}
-.table-filters,
-.dashboard-table-filters{display:flex;gap:6px;align-items:center;flex-wrap:wrap}
-table{width:100%;border-collapse:collapse;font-size:14px}
-thead th{
-  position:sticky;
-  top:0;
-  background:var(--card);
-  padding:10px;
-  text-align:right;
-  cursor:pointer;
-  transition:background 0.2s;
-  border-bottom:2px solid var(--glass);
+.dashboard-table-scroll {
+  margin-top: 16px;
+  border-radius: 18px;
+  overflow: auto;
+  border: 1px solid var(--glass);
 }
-thead th:hover{background:var(--glass)}
-td,th{padding:8px;border-bottom:1px solid rgba(255,255,255,0.04)}
-tbody tr:hover{background:var(--glass)}
 
-/* footer count */
-.table-footer,
-.dashboard-table-footer{padding:8px;color:var(--muted);text-align:left;font-size:12px}
+.dashboard-table-scroll table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 640px;
+}
 
-/* loader */
+thead th {
+  position: sticky;
+  top: 0;
+  background: var(--card);
+  padding: 14px 16px;
+  text-align: right;
+  cursor: pointer;
+  border-bottom: 1px solid var(--glass);
+  font-weight: 700;
+  transition: background 0.2s ease;
+}
+
+thead th:hover {
+  background: rgba(79, 140, 255, 0.12);
+}
+
+td,
+th {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--glass);
+}
+
+tbody tr:hover {
+  background: rgba(79, 140, 255, 0.08);
+}
+
+.dashboard-table-footer {
+  margin-top: 16px;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.dashboard-error-message {
+  background: rgba(239, 68, 68, 0.15);
+  color: #fff;
+  border-radius: 18px;
+  padding: 16px 20px;
+  border: 1px solid rgba(239, 68, 68, 0.3);
+}
+
 .loader,
-.dashboard-loader{
-  position:fixed;
-  inset:0;
-  display:none;
-  align-items:center;
-  justify-content:center;
-  background:linear-gradient(180deg,rgba(0,0,0,0.35),rgba(0,0,0,0.6));
-  backdrop-filter:blur(4px);
-  z-index:9999
+.dashboard-loader {
+  position: fixed;
+  inset: 0;
+  background: rgba(4, 8, 18, 0.6);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
 }
+
 .spinner,
-.dashboard-spinner{
-  width:72px;
-  height:72px;
-  border-radius:50%;
-  border:8px solid rgba(255,255,255,0.06);
-  border-top-color:var(--accent1);
-  animation:spin 1s linear infinite
-}
-@keyframes spin{to{transform:rotate(360deg)}}
-
-/* enhanced animations */
-.kpi, .panel, .donut-card{
-  animation:slideIn 0.5s ease forwards;
-}
-.kpi:nth-child(1){animation-delay:0.1s}
-.kpi:nth-child(2){animation-delay:0.2s}
-.kpi:nth-child(3){animation-delay:0.3s}
-.kpi:nth-child(4){animation-delay:0.4s}
-
-@keyframes slideIn{
-  from{opacity:0;transform:translateY(20px)}
-  to{opacity:1;transform:translateY(0)}
+.dashboard-spinner {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  border: 8px solid rgba(255, 255, 255, 0.12);
+  border-top-color: var(--accent1);
+  animation: spin 1s linear infinite;
 }
 
-/* responsive */
-@media(max-width:1024px){
-  .kpi{grid-column:span 6}
-  .panel{grid-column:span 12}
-  .donuts{grid-template-columns:repeat(auto-fit,minmax(150px,1fr))}
-}
-@media(max-width:640px){
-  .kpi{grid-column:span 12}
-  .container,
-  .dashboard-container{padding:12px;margin:10px auto}
-  .topbar,
-  .dashboard-topbar{flex-direction:column;text-align:center}
-  .donuts,
-  .dashboard-donut-area{grid-template-columns:1fr}
-  .filters,
-  .dashboard-filters{flex-wrap:wrap;gap:6px}
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
-/* arabic numbers and text enhancements */
-.value, .lastUpdate{
-  font-feature-settings: "tnum";
-  direction:ltr;
-  text-align:center;
+@media (max-width: 480px) {
+  .dashboard-nav-controls {
+    justify-content: center;
+  }
+
+  .dashboard-last-update {
+    width: 100%;
+    text-align: center;
+  }
+
+  .dashboard-search-input {
+    width: 100%;
+    min-width: auto;
+  }
 }
 
-/* map enhancements */
-#map{
-  border:1px solid var(--glass);
-  transition:all 0.3s;
-}
-#map:hover{
-  box-shadow:0 5px 15px rgba(0,0,0,0.3);
-}
-
-
-/* Map filter overlay */
-.map-filter{
-  position:absolute;
-  top:10px;
-  right:10px;
-  z-index:1000;
-  display:flex;
-  gap:6px;
-  align-items:center;
+@supports (backdrop-filter: blur(12px)) {
+  .card,
+  .dashboard-header,
+  .dashboard-controls-bar {
+    backdrop-filter: blur(12px);
+  }
 }


### PR DESCRIPTION
## Summary
- Rebuild the dashboard page markup to group header, controls, summary, and details sections inside a new grid shell.
- Replace the legacy dashboard stylesheet with a modern CSS grid system, refreshed theming, and responsive refinements.
- Update the tab toggle script to display the new grid layouts correctly when switching between summary and details views.

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd9d303a588331972f0308d3f25f34